### PR TITLE
Remove Timeout Option and Update Dependencies

### DIFF
--- a/nodes/Crawl4aiBasicCrawler/actions/crawlMultipleUrls.operation.ts
+++ b/nodes/Crawl4aiBasicCrawler/actions/crawlMultipleUrls.operation.ts
@@ -59,13 +59,6 @@ export const description: INodeProperties[] = [
         description: 'Whether to run browser in headless mode',
       },
       {
-        displayName: 'Timeout (Ms)',
-        name: 'timeout',
-        type: 'number',
-        default: 30000,
-        description: 'Maximum time to wait for the browser to load the page',
-      },
-      {
         displayName: 'User Agent',
         name: 'userAgent',
         type: 'string',

--- a/nodes/Crawl4aiBasicCrawler/actions/crawlSingleUrl.operation.ts
+++ b/nodes/Crawl4aiBasicCrawler/actions/crawlSingleUrl.operation.ts
@@ -59,13 +59,6 @@ export const description: INodeProperties[] = [
         description: 'Whether to run browser in headless mode',
       },
       {
-        displayName: 'Timeout (Ms)',
-        name: 'timeout',
-        type: 'number',
-        default: 30000,
-        description: 'Maximum time to wait for the browser to load the page',
-      },
-      {
         displayName: 'User Agent',
         name: 'userAgent',
         type: 'string',

--- a/nodes/Crawl4aiBasicCrawler/helpers/apiClient.ts
+++ b/nodes/Crawl4aiBasicCrawler/helpers/apiClient.ts
@@ -241,7 +241,6 @@ export class Crawl4aiClient {
           type: 'dict',
           value: config.viewport,
         } : { type: 'dict', value: { width: 1280, height: 800 } },
-        timeout: config.timeout || 30000,
         user_agent: config.userAgent,
       },
     };

--- a/nodes/Crawl4aiBasicCrawler/helpers/apiClient.ts
+++ b/nodes/Crawl4aiBasicCrawler/helpers/apiClient.ts
@@ -1,5 +1,4 @@
-import { IExecuteFunctions } from 'n8n-workflow';
-import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+import axios, { AxiosInstance } from 'axios';
 import { Crawl4aiApiCredentials, CrawlerRunConfig, CrawlResult } from './interfaces';
 
 /**
@@ -181,6 +180,10 @@ export class Crawl4aiClient {
         cache_mode: options.cacheMode || 'enabled',
         js_code: options.jsCode,
         css_selector: options.cssSelector,
+        viewport: {
+          width: options.browserConfig?.viewportWidth || 1280,
+          height: options.browserConfig?.viewportHeight || 800,
+        },
       };
 
       // Add extraction strategy if provided
@@ -254,7 +257,6 @@ export class Crawl4aiClient {
       cache_mode: config.cacheMode || 'enabled',
       stream: config.streamEnabled || false,
       page_timeout: config.pageTimeout || 30000,
-      request_timeout: config.requestTimeout || 30000,
       js_code: config.jsCode,
       js_only: config.jsOnly || false,
       css_selector: config.cssSelector,
@@ -263,7 +265,6 @@ export class Crawl4aiClient {
       check_robots_txt: config.checkRobotsTxt || false,
       word_count_threshold: config.wordCountThreshold || 0,
       session_id: config.sessionId,
-      max_retries: config.maxRetries || 3,
     };
 
     // Add extraction strategy if present

--- a/nodes/Crawl4aiBasicCrawler/helpers/interfaces.ts
+++ b/nodes/Crawl4aiBasicCrawler/helpers/interfaces.ts
@@ -36,7 +36,6 @@ export interface BrowserConfig {
     width: number;
     height: number;
   };
-  timeout?: number;
   userAgent?: string;
 }
 

--- a/nodes/Crawl4aiBasicCrawler/helpers/utils.ts
+++ b/nodes/Crawl4aiBasicCrawler/helpers/utils.ts
@@ -32,7 +32,6 @@ export function createBrowserConfig(options: IDataObject): BrowserConfig {
       width: options.viewportWidth ? Number(options.viewportWidth) : 1280,
       height: options.viewportHeight ? Number(options.viewportHeight) : 800,
     },
-    timeout: options.timeout ? Number(options.timeout) : 30000,
     userAgent: options.userAgent ? String(options.userAgent) : undefined,
   };
 }

--- a/package.json
+++ b/package.json
@@ -45,16 +45,16 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.1",
-    "@types/node": "^22.14.1",
+    "@types/node": "^22.13.9",
     "@types/request": "^2.48.12",
     "@types/request-promise-native": "^1.0.21",
-    "@typescript-eslint/eslint-plugin": "^7.15.0",
-    "@typescript-eslint/parser": "^7.15.0",
-    "eslint": "^8.56.0",
+    "@typescript-eslint/eslint-plugin": "^8.26.1",
+    "@typescript-eslint/parser": "^8.26.1",
+    "eslint": "^9.22.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-n8n-nodes-base": "^1.16.3",
     "eslint-plugin-prettier": "^5.0.0",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "n8n-core": "^1.79.1",
     "n8n-workflow": "^1.82.0",
     "prettier": "^3.1.0",
@@ -62,6 +62,6 @@
     "typescript": "~5.5.4"
   },
   "dependencies": {
-    "axios": "^1.6.5"
+    "axios": "^1.7.0"
   }
 }


### PR DESCRIPTION
This pull request removes the timeout option from the Crawl4aiBasicCrawler node and updates dependencies.

The timeout option was deemed unnecessary as it can be controlled from the Crawl4ai API.

This change simplifies the node's configuration and aligns it with the API's capabilities. Additionally, this PR updates axios dependency to the latest version as well.

My current working env:

- Docker: 28.0.0
- n8n image: 1.94.1
- Crawl4AI image:  0.6.0-r1
- Node: 22.14.0

Working examples:

![20f4r1pKz2](https://github.com/user-attachments/assets/73019cf2-1827-4f98-91ed-21bd74e101d3)
![pkWg9iFrC6](https://github.com/user-attachments/assets/63401dad-e799-4a9f-918a-1a23eb812dae)


Thanks to @golfamigo for compiling this beast together.